### PR TITLE
Refine tickers API test

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1,2 +1,15 @@
-import requests
-print(requests.get("http://127.0.0.1:8000/tickers").text)
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.dirname(__file__))
+from api.main import app
+
+client = TestClient(app)
+
+def test_get_tickers():
+    response = client.get("/tickers")
+    assert response.status_code == 200
+    data = response.json()
+    assert "tickers" in data
+    assert isinstance(data["tickers"], list)


### PR DESCRIPTION
## Summary
- replace external request with FastAPI TestClient for tickers endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688beb029c8883319bfd9b071e47d69d