### PR TITLE
Refactor ML preprocessing and move signals to DB

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -39,7 +39,7 @@ ml:
     rolling_window: 10
 
 database:
-  host: "ml-postgres"
+  host: "db"
   port: 5432
   name: ml_db
   user: ml_user

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,9 +1,10 @@
+import os
 import streamlit as st
 import requests
 import pandas as pd
 
-# Używamy hosta 'localhost', ponieważ dashboard działa lokalnie
-API_URL = "http://backend:8000"
+# Use backend service inside Docker; override with BACKEND_URL for local runs
+API_URL = os.getenv("BACKEND_URL", "http://backend:8000")
 
 st.title("📊 ML Trading Bot Dashboard")
 

--- a/ml/utils.py
+++ b/ml/utils.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from sklearn.preprocessing import MinMaxScaler
+
+
+def prepare_close_series(df: pd.DataFrame, window: int = 10):
+    """Apply rolling mean and MinMax scaling to close column.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input dataframe expected to contain ``close`` column.
+    window : int
+        Rolling window size for moving average.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, np.ndarray, MinMaxScaler]
+        Tuple containing processed dataframe, scaled close series and fitted scaler.
+    """
+    data = df.copy()
+    data.columns = data.columns.str.lower()
+    if "close" not in data.columns:
+        raise ValueError("Brak kolumny 'close' w danych.")
+
+    data["close_ma"] = data["close"].rolling(window=window).mean()
+    data = data.dropna(subset=["close_ma"]).reset_index(drop=True)
+
+    scaler = MinMaxScaler()
+    data["close_scaled"] = scaler.fit_transform(data[["close_ma"]])
+
+    return data, data["close_scaled"].values.astype("float32"), scaler


### PR DESCRIPTION
## Summary
- share LSTM preprocessing in `prepare_close_series`
- fetch tickers, intervals and signals from PostgreSQL instead of CSV
- allow dashboard to point to backend via `BACKEND_URL`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688bf8e34ce4833194bc69dd6ba6f26e